### PR TITLE
Uitgebreidere mailcontrole

### DIFF
--- a/web/common/formfunctions.php
+++ b/web/common/formfunctions.php
@@ -78,6 +78,9 @@ EOT;
     	if (!filter_var($_POST[$email], FILTER_VALIDATE_EMAIL)) {
     	    addvalidationerror('Geen geldig e-mailadres ingevuld!');
     	}
+    	elseif (!checkdnsrr(array_pop(explode("@",$_POST[$email])),"MX")) {
+    	    addvalidationerror('Geen geldig e-mailadres ingevuld!');	
+    	}
     }
 
     function comparepassword ($pass1, $pass2) {


### PR DESCRIPTION
Controle of voor het opgegeven maildomein een MX record bestaat. Zo niet, dan is het geen geldig mailadres en mag de afbeelding niet ingestuurd worden (wij kunnen toch niet antwoorden).